### PR TITLE
locking some dev dependencies, fixing php 7.4 serialization issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "phpstan/phpstan": "^0.11.2",
-        "friendsofphp/php-cs-fixer": "^2.11",
+        "phpstan/phpstan": "0.11.15",
+        "friendsofphp/php-cs-fixer": "2.15.2",
         "maglnet/composer-require-checker": "^1.1.0",
         "phpro/grumphp": "^0.14.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 7
+    inferPrivatePropertyTypeFromConstructor: true
     paths:
         - ./
     excludes_analyse:

--- a/src/Zend/Server/Reflection/Function/Abstract.php
+++ b/src/Zend/Server/Reflection/Function/Abstract.php
@@ -83,6 +83,11 @@ abstract class Zend_Server_Reflection_Function_Abstract
     protected $_prototypes = array();
 
     /**
+     * @var string
+     */
+    protected $functionName;
+
+    /**
      * @var string|array
      */
     private $_return;
@@ -117,6 +122,8 @@ abstract class Zend_Server_Reflection_Function_Abstract
         if (is_array($argv)) {
             $this->_argv = $argv;
         }
+
+        $this->functionName = $r->getName();
 
         // If method call, need to store some info on the class
         if ($r instanceof ReflectionMethod) {
@@ -490,9 +497,21 @@ abstract class Zend_Server_Reflection_Function_Abstract
     {
         if ($this->_reflection instanceof ReflectionMethod) {
             $class             = new ReflectionClass($this->_class);
-            $this->_reflection = new ReflectionMethod($class->newInstance(), $this->getName());
+            $this->_reflection = new ReflectionMethod($class->newInstance(), $this->functionName);
         } else {
-            $this->_reflection = new ReflectionFunction($this->getName());
+            $this->_reflection = new ReflectionFunction($this->functionName);
         }
+    }
+
+    public function __sleep()
+    {
+        return array(
+            '_argv',
+            '_config',
+            '_class',
+            '_description',
+            '_namespace',
+            'functionName',
+        );
     }
 }

--- a/src/Zend/Server/Reflection/Method.php
+++ b/src/Zend/Server/Reflection/Method.php
@@ -72,6 +72,8 @@ class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abst
             $this->_argv = $argv;
         }
 
+        $this->functionName = $r->getName();
+
         // If method call, need to store some info on the class
         $this->_class = $class->getName();
 
@@ -100,6 +102,6 @@ class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abst
     public function __wakeup()
     {
         $this->_classReflection = new Zend_Server_Reflection_Class(new ReflectionClass($this->_class), $this->getNamespace(), $this->getInvokeArguments());
-        $this->_reflection      = new ReflectionMethod($this->_classReflection->getName(), $this->getName());
+        $this->_reflection      = new ReflectionMethod($this->_class, $this->functionName);
     }
 }


### PR DESCRIPTION
PHP 7.4 now throws an exception if Reflection* objects are serialized (https://bugs.php.net/bug.php?id=76737), which this component will do when the reflection classes are serialized.

Modified the `__sleep` and `__wake` methods of the reflection classes to be sure they don't serialize anything that might contain the php reflection objects, but do store enough data when serialized that they can rebuild the reflection objects when unserialized.